### PR TITLE
 Enable qodana annotations for PRs from forks. 

### DIFF
--- a/.github/workflows/annotate-qodana-results.yml
+++ b/.github/workflows/annotate-qodana-results.yml
@@ -1,0 +1,36 @@
+name: Annotate Qodana Results
+
+on:
+
+permissions:
+  checks: write
+
+  workflow_run:
+    workflows: ["tests"]
+    types:
+      - completed
+jobs:
+  annotate:
+    runs-on: ubuntu-latest
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Qodana - Download Results
+        env:
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: gh run download --name "qodana-results" "$RUN_ID"
+      - name: Fetch PR Number
+        env:
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: gh run download --name "pr" "$RUN_ID"
+      - name: Extract PR Number
+        id: pr-number
+        run: echo "::set-output name=pr::$(grep -o '^[0-9]\+$' pr.txt)"
+      - name: SARIF Annotator
+        uses: SirYwell/sarif-annotator@v0.2.1
+        with:
+          source: qodana
+          report-path: "qodana.sarif.json"
+          baseline-state-filter: 'new'
+          pr-number: ${{ steps.pr-number.outputs.pr }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -167,7 +167,9 @@ jobs:
           results-dir:  "${{ github.workspace }}/result/master"
       - name: Qodana - Code Inspection
         uses: JetBrains/qodana-action@cd7dc31b49427ce740ebf6255319b267801d08cf # renovate: tag=v3.2.1
+        # the action's exit codes are a bit unreliable at the moment
         continue-on-error: true
+        id: qodana # later used by the sarif annotator step
         with:
           linter: qodana-jvm-community
           project-dir: "${{ github.workspace }}/pull_request"
@@ -175,34 +177,9 @@ jobs:
           baseline-path: "/data/results/master/qodana.sarif.json"
           baseline-include-absent: true
           results-dir:  "${{ github.workspace }}/result"
-          fail-threshold: 1
-      - name: Print problems(full)
-        run: jq '.runs | .[0].results | map(select (.baselineState == "new"))' ${{ github.workspace }}/result/qodana.sarif.json
-      - name: Print problems(short)
-        run: |
-          jq -r '.runs
-          | .[0].results
-          | map(
-             select (.baselineState == "new") |
-             {
-                 text: .message.text,
-                 location: .locations | map({
-                       snippet: .physicalLocation.contextRegion.snippet.text,
-                       file: .physicalLocation.artifactLocation.uri,
-                       position: ((.physicalLocation.contextRegion.startLine | tostring) + ":" + (.physicalLocation.contextRegion.startColumn | tostring))
-                   })
-             }
-          )
-          | map(
-             "## " + .text + "\n" +
-             (.location
-               | map(
-                 "In file " + .file + " at " + .position + "\n```java\n" + .snippet + "\n```"
-               )
-               | join("\n")
-             )
-          )
-          | join("\n\n----\n\n")' \
-          ${{ github.workspace }}/result/qodana.sarif.json
-          VIOLATIONS=$(jq '.runs | .[0].results | map(select (.baselineState == "new")) | length' ${{ github.workspace }}/result/qodana.sarif.json)
-          if [ "$VIOLATIONS" -gt "0" ]; then exit 1; fi
+      - name: SARIF Annotator
+        uses: SirYwell/sarif-annotator@v0.2.1
+        with:
+          source: qodana
+          report-path: ${{ steps.qodana.outputs.results-json-path }}
+          baseline-state-filter: 'new'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,8 @@
 # risk of someone injecting malicious code into a release and then simply
 # changing a tag.
 
+# Keep the name in sync with the name used in `workflow_run.workflows`,
+# in `annotate-qodana-results.yml` .
 name: tests
 on:
   pull_request:
@@ -177,9 +179,24 @@ jobs:
           baseline-path: "/data/results/master/qodana.sarif.json"
           baseline-include-absent: true
           results-dir:  "${{ github.workspace }}/result"
-      - name: SARIF Annotator
-        uses: SirYwell/sarif-annotator@v0.2.1
+      # Save the results of the qodana analysis and the PR number.
+      # This is later used in the `annotate-qodana-results.yml` workflow
+      # to actually annotate the results. We split this job into two
+      # workflows because a workflow that is triggered by a PR from an external fork
+      # and does NOT have permission to add annotations, if the workflow trigger is `pull_request`.
+      # This workflow therefore computes the qodana results on the untrusted PR and stores them as an artifact.
+      # The `annotate-qodana-results.yml` workflow then receives the artifacts and performs the annotation based
+      # on the artifact.
+      - name: Qodana - Upload Results
+        uses: actions/upload-artifact@v2
         with:
-          source: qodana
-          report-path: ${{ steps.qodana.outputs.results-json-path }}
-          baseline-state-filter: 'new'
+          name: qodana-results
+          path: ${{ steps.qodana.outputs.results-json-path }}
+          retention-days: 1
+      - name: Save PR number
+        run: echo ${{ github.event.number }} > .pr.txt
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr.txt
+          retention-days: 1


### PR DESCRIPTION
This PR moves the annotation part from the `tests.yml` workflow
to a new workflow. This is done for security reasons, the `tests.yml`
workflow works on untrusted user-input. That's why it only produces
an artifact that is stored. The new workflow then ONLY has permissions
to use the checks API (used for annotations). It downloads the artifact
from the `tests.yml` workflow  and is limited to performing the
annotation based on this untrusted user-input. This is the only usage
of user-input in `annotate-qodana-results.yml` besides getting the
PR number, for which we check that it is indeed a number.